### PR TITLE
Xhyve Cleanup

### DIFF
--- a/drivers/xhyve/utils.go
+++ b/drivers/xhyve/utils.go
@@ -16,7 +16,7 @@ var (
 	//	ErrMachineNotExist  = errors.New("machine does not exist")
 	ErrDdNotFound       = errors.New("xhyve not found")
 	ErrUuidgenNotFound  = errors.New("uuidgen not found")
-	ErrUuid2macNotFound = errors.New("uuid2mac not found")
+	//	ErrUuid2macNotFound = errors.New("uuid2mac not found")
 	ErrHdiutilNotFound  = errors.New("hdiutil not found")
 )
 
@@ -59,21 +59,6 @@ func uuidgen() string {
 	out := stdout.String()
 	out = strings.Replace(out, "\n", "", -1)
 	return out
-}
-
-func uuid2mac(uuid string) string { // TODO deprecated
-	cmd := exec.Command("sudo", "uuid2mac", uuid)
-
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	log.Debugf("executing: %v %v %v", cmd, uuid, stdout.String())
-
-	err := cmd.Run()
-	if err != nil {
-		log.Error(err)
-	}
-
-	return stdout.String()
 }
 
 func hdiutil(args ...string) error {

--- a/drivers/xhyve/utils.go
+++ b/drivers/xhyve/utils.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"runtime"
 
 	"github.com/docker/machine/log"
 )
@@ -18,6 +20,8 @@ var (
 	ErrUuidgenNotFound  = errors.New("uuidgen not found")
 	//	ErrUuid2macNotFound = errors.New("uuid2mac not found")
 	ErrHdiutilNotFound  = errors.New("hdiutil not found")
+	ErrVBMNotFound      = errors.New("VBoxManage not found")
+	vboxManageCmd       = setVBoxManageCmd()
 )
 
 func dd(input string, output string, block string, count int) (string, string, error) { // TODO
@@ -72,4 +76,74 @@ func hdiutil(args ...string) error {
 	}
 
 	return nil
+}
+
+// detect the VBoxManage cmd's path if needed
+func setVBoxManageCmd() string {
+	cmd := "VBoxManage"
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	if runtime.GOOS == "windows" {
+		if p := os.Getenv("VBOX_INSTALL_PATH"); p != "" {
+			if path, err := exec.LookPath(filepath.Join(p, cmd)); err == nil {
+				return path
+			}
+		}
+		if p := os.Getenv("VBOX_MSI_INSTALL_PATH"); p != "" {
+			if path, err := exec.LookPath(filepath.Join(p, cmd)); err == nil {
+				return path
+			}
+		}
+		// look at HKEY_LOCAL_MACHINE\SOFTWARE\Oracle\VirtualBox\InstallDir
+		p := "C:\\Program Files\\Oracle\\VirtualBox"
+		if path, err := exec.LookPath(filepath.Join(p, cmd)); err == nil {
+			return path
+		}
+	}
+	return cmd
+}
+
+
+func vbm(args ...string) error {
+	_, _, err := vbmOutErr(args...)
+	return err
+}
+
+func vbmOut(args ...string) (string, error) {
+	stdout, _, err := vbmOutErr(args...)
+	return stdout, err
+}
+
+func vbmOutErr(args ...string) (string, string, error) {
+	cmd := exec.Command(vboxManageCmd, args...)
+	log.Debugf("executing: %v %v", vboxManageCmd, strings.Join(args, " "))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	stderrStr := stderr.String()
+	log.Debugf("STDOUT: %v", stdout.String())
+	log.Debugf("STDERR: %v", stderrStr)
+	if err != nil {
+		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
+			err = ErrVBMNotFound
+		}
+	} else {
+		// VBoxManage will sometimes not set the return code, but has a fatal error
+		// such as VBoxManage.exe: error: VT-x is not available. (VERR_VMX_NO_VMX)
+		if strings.Contains(stderrStr, "error:") {
+			err = fmt.Errorf("%v %v failed: %v", vboxManageCmd, strings.Join(args, " "), stderrStr)
+		}
+	}
+	return stdout.String(), stderrStr, err
+}
+
+func vboxVersionDetect() (string, error) {
+	ver, err := vbmOut("-v");
+	if  err != nil {
+		return "", err
+	}
+	return ver, err
 }

--- a/drivers/xhyve/xhyve.go
+++ b/drivers/xhyve/xhyve.go
@@ -379,7 +379,7 @@ func (d *Driver) createUUIDFile() error {
 func (d *Driver) getIPfromDHCPLease() (string, error) {
 	var dhcpfh *os.File
 	var dhcpcontent []byte
-	// var macaddr string
+	var macaddr string
 	var err error
 	var lastipmatch string
 	var currentip string
@@ -413,7 +413,9 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 
 		if matches := leasemac.FindStringSubmatch(line); matches != nil {
 			currentip = lastipmatch
-			macaddr = matches
+			macaddr = matches[1]
+			log.Debug(macaddr)
+                        continue
 		}
 	}
 

--- a/drivers/xhyve/xhyve.go
+++ b/drivers/xhyve/xhyve.go
@@ -413,6 +413,7 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 
 		if matches := leasemac.FindStringSubmatch(line); matches != nil {
 			currentip = lastipmatch
+			macaddr = matches
 		}
 	}
 
@@ -420,7 +421,7 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 		return "", fmt.Errorf("IP not found for MAC %s in DHCP leases", leasemac)
 	}
 
-	if leasemac == "" {
+	if macaddr == "" {
                 return "", fmt.Errorf("couldn't find MAC address in DHCP leases file %s", dhcpfile)
         }
 

--- a/drivers/xhyve/xhyve.go
+++ b/drivers/xhyve/xhyve.go
@@ -188,7 +188,7 @@ func (d *Driver) PreCreateCheck() error {
 	reVersion := regexp.MustCompile(`^(\d+\.)?$`)
 	ver, err := vboxVersionDetect()
 	majorVersion := reVersion.FindString(ver)
-	if majorVersion != "5" && err != nil {
+	if majorVersion != "5" || majorVersion != "" && err != nil {
 		return fmt.Errorf("Virtual Box version 4 or lower will cause a kernel panic if xhyve tries to run." +
 				"You are running version: " +
 				ver +

--- a/drivers/xhyve/xhyve.go
+++ b/drivers/xhyve/xhyve.go
@@ -185,6 +185,15 @@ func (d *Driver) GetState() (state.State, error) { // TODO
 }
 
 func (d *Driver) PreCreateCheck() error {
+	reVersion := regexp.MustCompile(`^(\d+\.)?$`)
+	ver, err := vboxVersionDetect()
+	majorVersion := reVersion.FindString(ver)
+	if majorVersion != "5" && err != nil {
+		return fmt.Errorf("Virtual Box version 4 or lower will cause a kernel panic if xhyve tries to run." +
+				"You are running version: " +
+				ver +
+				" Please upgrade to version 5 at https://www.virtualbox.org/wiki/Downloads")
+	}
 	return nil
 }
 

--- a/drivers/xhyve/xhyvecmd.go
+++ b/drivers/xhyve/xhyvecmd.go
@@ -38,7 +38,7 @@ func setXhyveCmd() string { // TODO
 
 func xhyve(args ...string) (string, error) { // TODO
 	var Password string
-	cmd := exec.Command("sudo", "-S", "xhyve")
+	cmd := exec.Command("sudo", "-S", XhyveCmd)
 	cmd.Stdin = strings.NewReader(Password)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
This cleans up the uuid2mac required commands and associated calls. Mac addresses are now taken from the assigned address by DHCP.

This is possibly less configurable, but it eliminates a requirement for running.

@zchee for combining with your PR.
